### PR TITLE
Update STUNExternalIP.c

### DIFF
--- a/STUNExternalIP.c
+++ b/STUNExternalIP.c
@@ -14,6 +14,7 @@
 #include <string.h>
 #include <unistd.h>
 #include <time.h>
+#include <sys/time.h
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>


### PR DESCRIPTION
STUNExternalIP.c: In function 'getPublicIPAddress':
STUNExternalIP.c:195:12: error: variable 'tv' has initializer but incomplete type
     struct timeval tv = {5, 0};
            ^~~~~~~
STUNExternalIP.c:195:26: warning: excess elements in struct initializer
     struct timeval tv = {5, 0};
                          ^
STUNExternalIP.c:195:26: note: (near initialization for 'tv')
STUNExternalIP.c:195:29: warning: excess elements in struct initializer
     struct timeval tv = {5, 0};
                             ^
STUNExternalIP.c:195:29: note: (near initialization for 'tv')
STUNExternalIP.c:195:20: error: storage size of 'tv' isn't known
     struct timeval tv = {5, 0};
                    ^~
STUNExternalIP.c:197:62: error: invalid application of 'sizeof' to incomplete type 'struct timeval'
     setsockopt(socketd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(struct timeval));
                                                              ^~~~~~
make: *** [<builtin>: STUNExternalIP.o] Error 1


Compiling the code in alpine linux produces the above error. Including sys/time.h solves it.